### PR TITLE
Comment out section on COR Proposal

### DIFF
--- a/about/bylaws/index.md
+++ b/about/bylaws/index.md
@@ -8,9 +8,10 @@ title: Bylaws
 </div>
 
 These bylaws are made available with the intent for other FRC teams to copy, modify, and enjoy. If there are any questions about the process we took to create these bylaws, please let us know.
-
+<!--
 ### New Leadership Structure
 The team's officers have proposed a new leadership structure that is being trialed this year. The full proposal can be found in the link below.
 <div style="text-align:center; padding:5px;">
   <a class="btn" href="https://docs.google.com/document/d/1uRfHLhyWTfdJyHK7mCgETE3aGG9VLCgLHEZlouQhKus">COR Proposal</a>
 </div>
+-->


### PR DESCRIPTION
This section of the Bylaws page is from last year. It wasn't updated when we ratified the bylaws at the end of the year. It also doesn't match what this year's officers are planning. It's up to this year's officers to decide what, if anything, should be shared about proposed changes to the team's structure and bylaws.